### PR TITLE
Add dependencies to ril-configs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,7 @@ Depends: ${misc:Depends},
          adaptation-hybris (= ${binary:Version}),
          adaptation-hybris-phone (= ${binary:Version}),
          ofono-ril-binder-plugin,
+         ofono-config-ril-binder,
 Description: adaptation hybris phone metapackage
 
 Package: adaptation-hybris-api28

--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,15 @@ Depends: ${misc:Depends},
          ofono-config-ril-binder,
 Description: adaptation hybris phone metapackage
 
+Package: adaptation-hybris-api28-phone-dual-sim
+Architecture: all
+Depends: ${misc:Depends},
+         adaptation-hybris-api28-phone (= ${binary:Version}),
+         ofono-config-ril-binder-dual-sim,
+Description: Base metapackage for hybris-api28 adaptations (Dual sim support)
+ This metapackage depends on the required packages
+ to allow Dual Sim support.
+
 Package: adaptation-hybris-api28
 Architecture: all
 Depends: ${misc:Depends},


### PR DESCRIPTION
This includes a new metapackage for the "dual-sim" feature.