### PR TITLE
[adaptation-hybris-api28] added ofono2mm and removed phosh-config-ofono

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Architecture: all
 Depends: ${misc:Depends},
          adaptation-hybris (= ${binary:Version}),
          ofono,
-         phosh-config-ofono,
+         ofono2mm,
          droidian-quirks-calls-config-ofono,
          audiosystem-passthrough,
 Description: Metapackage for hybris phones


### PR DESCRIPTION
Related: droidian/droidian-apt-config#1
Adding ofono2mm.

Also, removing phosh-config-ofono as it is more reliable to use modemmanager as phosh wwan backend.